### PR TITLE
feat: render additionalProperties (typed maps)

### DIFF
--- a/_extensions/quarto-openapi/_extension.yml
+++ b/_extensions/quarto-openapi/_extension.yml
@@ -1,6 +1,6 @@
 title: quarto-openapi
 author: Posit Software, PBC
-version: 0.3.2
+version: 0.4.0
 quarto-required: ">=1.6.0"
 contributes:
   metadata:

--- a/_extensions/quarto-openapi/lib/schema.ts
+++ b/_extensions/quarto-openapi/lib/schema.ts
@@ -231,6 +231,42 @@ function flattenProperties(
           description: buildDescription(resolved, requiredSet.has(name)),
         });
       }
+    } else if (
+      !resolved.properties &&
+      resolved.additionalProperties !== undefined &&
+      resolved.additionalProperties !== false
+    ) {
+      // Typed map: additionalProperties is a schema, $ref, or `true`.
+      const ap = resolved.additionalProperties;
+      const valueType = mapValueTypeLabel(spec, ap);
+      rows.push({
+        name: nameCell,
+        type: `\`map[string, ${valueType}]\``,
+        description: buildDescription(resolved, requiredSet.has(name)),
+      });
+      if (ap !== true) {
+        const valueSchema = isReference(ap) ? resolve<Schema>(spec, ap) : ap;
+        if (
+          valueSchema.type === "object" ||
+          valueSchema.properties ||
+          valueSchema.allOf
+        ) {
+          const effective = valueSchema.allOf
+            ? mergeAllOf(spec, valueSchema.allOf)
+            : valueSchema;
+          if (effective.properties) {
+            rows.push(
+              ...flattenProperties(
+                spec,
+                effective.properties,
+                effective.required,
+                `${displayName}{}`,
+                depth + 1,
+              ),
+            );
+          }
+        }
+      }
     } else {
       rows.push({
         name: nameCell,
@@ -274,6 +310,19 @@ function buildDescription(schema: Schema, isRequired: boolean): string {
 }
 
 const semanticFormats = new Set(["date-time", "date", "time", "duration", "uuid", "uri", "uri-reference", "email", "hostname", "ipv4", "ipv6", "byte", "binary", "password"]);
+
+function mapValueTypeLabel(
+  _spec: OpenAPISpec,
+  value: Schema | Reference | boolean,
+): string {
+  if (value === true) return "any";
+  if (value === false) return "object";
+  if (isReference(value)) {
+    return value.$ref.split("/").pop() || "object";
+  }
+  if (value.type === "object" || value.properties || value.allOf) return "object";
+  return value.type || "object";
+}
 
 function formatTypeString(schema: Schema): string {
   let type = schema.type || "unknown";

--- a/_extensions/quarto-openapi/lib/schema.ts
+++ b/_extensions/quarto-openapi/lib/schema.ts
@@ -42,6 +42,14 @@ export function renderSchema(
     return renderArray(spec, resolved, lines);
   }
 
+  if (
+    !resolved.properties &&
+    resolved.additionalProperties !== undefined &&
+    resolved.additionalProperties !== false
+  ) {
+    return renderMap(spec, resolved, lines);
+  }
+
   if (type === "object" || resolved.properties) {
     return renderObject(spec, resolved, lines);
   }
@@ -117,6 +125,33 @@ function renderArray(
     lines.push(`Array of ${itemType}`);
   }
 
+  return lines;
+}
+
+function renderMap(
+  spec: OpenAPISpec,
+  schema: Schema,
+  lines: string[],
+): string[] {
+  const ap = schema.additionalProperties!;
+  if (typeof ap === "boolean") {
+    if (ap === true) {
+      lines.push("Map of string to any");
+    }
+    return lines;
+  }
+  const valueSchema = isReference(ap) ? resolve<Schema>(spec, ap) : ap;
+  if (
+    valueSchema.type === "object" ||
+    valueSchema.properties ||
+    valueSchema.allOf
+  ) {
+    lines.push("Map of string to object:");
+    lines.push("");
+    lines.push(...renderSchema(spec, valueSchema));
+  } else {
+    lines.push(`Map of string to ${formatPrimitiveType(valueSchema)}`);
+  }
   return lines;
 }
 

--- a/example/_extensions/quarto-openapi/_extension.yml
+++ b/example/_extensions/quarto-openapi/_extension.yml
@@ -1,6 +1,6 @@
 title: quarto-openapi
 author: Posit Software, PBC
-version: 0.3.2
+version: 0.4.0
 quarto-required: ">=1.6.0"
 contributes:
   metadata:

--- a/example/_extensions/quarto-openapi/lib/schema.ts
+++ b/example/_extensions/quarto-openapi/lib/schema.ts
@@ -42,6 +42,14 @@ export function renderSchema(
     return renderArray(spec, resolved, lines);
   }
 
+  if (
+    !resolved.properties &&
+    resolved.additionalProperties !== undefined &&
+    resolved.additionalProperties !== false
+  ) {
+    return renderMap(spec, resolved, lines);
+  }
+
   if (type === "object" || resolved.properties) {
     return renderObject(spec, resolved, lines);
   }
@@ -117,6 +125,33 @@ function renderArray(
     lines.push(`Array of ${itemType}`);
   }
 
+  return lines;
+}
+
+function renderMap(
+  spec: OpenAPISpec,
+  schema: Schema,
+  lines: string[],
+): string[] {
+  const ap = schema.additionalProperties!;
+  if (typeof ap === "boolean") {
+    if (ap === true) {
+      lines.push("Map of string to any");
+    }
+    return lines;
+  }
+  const valueSchema = isReference(ap) ? resolve<Schema>(spec, ap) : ap;
+  if (
+    valueSchema.type === "object" ||
+    valueSchema.properties ||
+    valueSchema.allOf
+  ) {
+    lines.push("Map of string to object:");
+    lines.push("");
+    lines.push(...renderSchema(spec, valueSchema));
+  } else {
+    lines.push(`Map of string to ${formatPrimitiveType(valueSchema)}`);
+  }
   return lines;
 }
 
@@ -231,6 +266,42 @@ function flattenProperties(
           description: buildDescription(resolved, requiredSet.has(name)),
         });
       }
+    } else if (
+      !resolved.properties &&
+      resolved.additionalProperties !== undefined &&
+      resolved.additionalProperties !== false
+    ) {
+      // Typed map: additionalProperties is a schema, $ref, or `true`.
+      const ap = resolved.additionalProperties;
+      const valueType = mapValueTypeLabel(spec, ap);
+      rows.push({
+        name: nameCell,
+        type: `\`map[string, ${valueType}]\``,
+        description: buildDescription(resolved, requiredSet.has(name)),
+      });
+      if (ap !== true) {
+        const valueSchema = isReference(ap) ? resolve<Schema>(spec, ap) : ap;
+        if (
+          valueSchema.type === "object" ||
+          valueSchema.properties ||
+          valueSchema.allOf
+        ) {
+          const effective = valueSchema.allOf
+            ? mergeAllOf(spec, valueSchema.allOf)
+            : valueSchema;
+          if (effective.properties) {
+            rows.push(
+              ...flattenProperties(
+                spec,
+                effective.properties,
+                effective.required,
+                `${displayName}{}`,
+                depth + 1,
+              ),
+            );
+          }
+        }
+      }
     } else {
       rows.push({
         name: nameCell,
@@ -274,6 +345,19 @@ function buildDescription(schema: Schema, isRequired: boolean): string {
 }
 
 const semanticFormats = new Set(["date-time", "date", "time", "duration", "uuid", "uri", "uri-reference", "email", "hostname", "ipv4", "ipv6", "byte", "binary", "password"]);
+
+function mapValueTypeLabel(
+  _spec: OpenAPISpec,
+  value: Schema | Reference | boolean,
+): string {
+  if (value === true) return "any";
+  if (value === false) return "object";
+  if (isReference(value)) {
+    return value.$ref.split("/").pop() || "object";
+  }
+  if (value.type === "object" || value.properties || value.allOf) return "object";
+  return value.type || "object";
+}
 
 function formatTypeString(schema: Schema): string {
   let type = schema.type || "unknown";

--- a/tests/schema_test.ts
+++ b/tests/schema_test.ts
@@ -360,3 +360,34 @@ Deno.test("flattenProperties: any-valued map renders map[string, any]", () => {
   assertStringIncludes(output, "`config`");
   assertStringIncludes(output, "map[string, any]");
 });
+
+Deno.test("renderSchema: top-level $ref map renders 'Map of' and the value table", () => {
+  const spec = specWithSchemas({
+    WindowCounts: {
+      type: "object",
+      properties: { total: { type: "integer", description: "Total" } },
+    },
+  });
+  const schema: Schema = {
+    type: "object",
+    additionalProperties: { $ref: "#/components/schemas/WindowCounts" },
+  };
+
+  const output = rendered(spec, schema);
+
+  assertStringIncludes(output, "Map of string to object");
+  assertStringIncludes(output, "`total`");
+  assertStringIncludes(output, "Total");
+});
+
+Deno.test("renderSchema: top-level primitive map renders 'Map of string to <type>'", () => {
+  const spec = specWithSchemas();
+  const schema: Schema = {
+    type: "object",
+    additionalProperties: { type: "string" },
+  };
+
+  const output = rendered(spec, schema);
+
+  assertStringIncludes(output, "Map of string to string");
+});

--- a/tests/schema_test.ts
+++ b/tests/schema_test.ts
@@ -391,3 +391,15 @@ Deno.test("renderSchema: top-level primitive map renders 'Map of string to <type
 
   assertStringIncludes(output, "Map of string to string");
 });
+
+Deno.test("renderSchema: top-level any map renders 'Map of string to any'", () => {
+  const spec = specWithSchemas();
+  const schema: Schema = {
+    type: "object",
+    additionalProperties: true,
+  };
+
+  const output = rendered(spec, schema);
+
+  assertStringIncludes(output, "Map of string to any");
+});

--- a/tests/schema_test.ts
+++ b/tests/schema_test.ts
@@ -302,3 +302,61 @@ Deno.test("renderSchema: nullable with suppressed format renders type|null witho
   assertStringIncludes(output, "`integer|null`");
   assert(!output.includes("int64"), "int64 should be suppressed even when nullable");
 });
+
+Deno.test("flattenProperties: $ref-valued map renders map row and recurses into value", () => {
+  const spec = specWithSchemas({
+    WindowCounts: {
+      type: "object",
+      properties: { total: { type: "integer", description: "Total" } },
+    },
+  });
+  const schema: Schema = {
+    type: "object",
+    properties: {
+      windows: {
+        type: "object",
+        description: "Counts by window",
+        additionalProperties: { $ref: "#/components/schemas/WindowCounts" },
+      },
+    },
+  };
+
+  const output = rendered(spec, schema);
+
+  assertStringIncludes(output, "`windows`");
+  assertStringIncludes(output, "map[string, WindowCounts]");
+  assertStringIncludes(output, "Counts by window");
+  // recurses into the value schema's properties
+  assertStringIncludes(output, "windows{}.total");
+  assertStringIncludes(output, "Total");
+});
+
+Deno.test("flattenProperties: primitive-valued map renders typed map row", () => {
+  const spec = specWithSchemas();
+  const schema: Schema = {
+    type: "object",
+    properties: {
+      flags: { type: "object", additionalProperties: { type: "boolean" } },
+    },
+  };
+
+  const output = rendered(spec, schema);
+
+  assertStringIncludes(output, "`flags`");
+  assertStringIncludes(output, "map[string, boolean]");
+});
+
+Deno.test("flattenProperties: any-valued map renders map[string, any]", () => {
+  const spec = specWithSchemas();
+  const schema: Schema = {
+    type: "object",
+    properties: {
+      config: { type: "object", additionalProperties: true },
+    },
+  };
+
+  const output = rendered(spec, schema);
+
+  assertStringIncludes(output, "`config`");
+  assertStringIncludes(output, "map[string, any]");
+});


### PR DESCRIPTION
Render OpenAPI `additionalProperties` in both rendering paths:

- `flattenProperties` (property tables): typed-map fields render as `map[string, <value>]` rows and recurse into $ref/object value schemas using a `{}` path suffix; `additionalProperties: true` renders `map[string, any]`.
- `renderSchema` (top-level bodies): a body that is itself a map renders "Map of string to <value>" and recurses into the value schema.

Adds a `mapValueTypeLabel` helper and tests in tests/schema_test.ts (ref-valued, primitive-valued, and any-valued maps, in both paths). Bumps the extension to 0.4.0.

Motivation: the downstream Posit Connect OpenAPI generator now emits `additionalProperties` for Go map fields; without this the docs render typed maps as a bare `object` and drop value schemas reachable only through `additionalProperties`.