### PR TITLE
feat: render x-experimental as an Experimental callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The single output page contains:
 - Endpoints (`###`) per operation, each with:
   - Method and path as inline code (e.g., `` `PUT /board/{row}/{column}` ``)
   - Deprecated callout (if `deprecated: true`)
+  - Experimental callout (if the `x-experimental: true` extension is set)
   - Description (may contain rich markdown from the spec)
   - Parameters table grouped by location (path, query, header, cookie)
   - Request body schema table

--- a/_extensions/quarto-openapi/lib/sections.ts
+++ b/_extensions/quarto-openapi/lib/sections.ts
@@ -297,10 +297,20 @@ function renderEndpoint(spec: OpenAPISpec, endpoint: Endpoint, options: RenderOp
   lines.push(`\`${methodBadge(method)} ${path}\``);
   lines.push("");
 
-  // Deprecated badge
+  // Deprecated callout
   if (operation.deprecated) {
-    lines.push("::: {.callout-warning}");
+    lines.push('::: {.callout-warning title="Deprecated"}');
     lines.push("This endpoint is deprecated.");
+    lines.push(":::");
+    lines.push("");
+  }
+
+  // Experimental callout
+  if (operation["x-experimental"]) {
+    lines.push('::: {.callout-note title="Experimental"}');
+    lines.push(
+      "This endpoint is experimental and may change or be removed in a future release without notice.",
+    );
     lines.push(":::");
     lines.push("");
   }

--- a/_extensions/quarto-openapi/lib/types.ts
+++ b/_extensions/quarto-openapi/lib/types.ts
@@ -60,6 +60,9 @@ export interface Operation {
   responses: Record<string, Response | Reference>;
   security?: SecurityRequirement[];
   deprecated?: boolean;
+  // OpenAPI vendor extension. The renderer relies only on truthiness; do not
+  // compare with === true.
+  "x-experimental"?: boolean;
 }
 
 export interface Parameter {

--- a/tests/render_test.ts
+++ b/tests/render_test.ts
@@ -1,4 +1,6 @@
 import {
+  assert,
+  assertFalse,
   assertStringIncludes,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
@@ -70,8 +72,75 @@ Deno.test("renderSection: deprecated endpoint shows callout", () => {
 
   const output = renderedSection(spec);
 
-  assertStringIncludes(output, ".callout-warning");
+  assertStringIncludes(output, '.callout-warning title="Deprecated"');
   assertStringIncludes(output, "deprecated");
+});
+
+Deno.test("renderSection: experimental endpoint shows callout", () => {
+  const spec = minimalSpec({
+    "/v1/experimental/widgets": {
+      get: {
+        operationId: "listWidgets",
+        summary: "List widgets",
+        "x-experimental": true,
+        responses: { "200": { description: "OK" } },
+      },
+    },
+  });
+
+  const output = renderedSection(spec);
+
+  assertStringIncludes(output, '.callout-note title="Experimental"');
+  assertStringIncludes(output, "experimental");
+});
+
+Deno.test("renderSection: non-experimental endpoint shows no experimental callout", () => {
+  const spec = minimalSpec({
+    "/v1/pets": {
+      get: {
+        operationId: "listPets",
+        summary: "List pets",
+        responses: { "200": { description: "OK" } },
+      },
+    },
+  });
+
+  const output = renderedSection(spec);
+
+  assertFalse(output.includes(".callout-note"));
+});
+
+Deno.test("renderSection: deprecated + experimental shows both callouts, deprecated first and before description", () => {
+  const spec = minimalSpec({
+    "/v1/experimental/bootstrap": {
+      post: {
+        operationId: "bootstrap",
+        summary: "Bootstrap",
+        description: "DESCRIPTION_MARKER body text.",
+        deprecated: true,
+        "x-experimental": true,
+        responses: { "200": { description: "OK" } },
+      },
+    },
+  });
+
+  const output = renderedSection(spec);
+
+  assertStringIncludes(output, ".callout-warning");
+  assertStringIncludes(output, ".callout-note");
+
+  const warningIndex = output.indexOf(".callout-warning");
+  const noteIndex = output.indexOf(".callout-note");
+  const descriptionIndex = output.indexOf("DESCRIPTION_MARKER");
+
+  assert(
+    warningIndex < noteIndex,
+    "deprecated callout should render before experimental",
+  );
+  assert(
+    noteIndex < descriptionIndex,
+    "callouts should render before the description",
+  );
 });
 
 Deno.test("renderSection: parameters rendered as grid table", () => {


### PR DESCRIPTION
## Summary

Renders operations carrying the OpenAPI vendor extension `x-experimental: true` as a titled `::: {.callout-note title="Experimental"}` block, parallel to the existing `deprecated` callout. The deprecated callout also gains `title="Deprecated"` so the two read uniformly (Quarto's default titles — "Note"/"Warning" — carry no domain meaning).

This is the quarto-openapi half of the Connect-side work that emits `x-experimental` for `@experimental` endpoints (separate plan).

## Changes

- **`types.ts`** — add `"x-experimental"?: boolean` to `Operation`. The renderer relies only on truthiness (no `=== true`).
- **`sections.ts`** — retitle the deprecated callout; emit the experimental callout immediately after it and before the description. Both are independent `if`s; when an op is both, deprecated renders first.
- **`render_test.ts`** — tighten the deprecated test to assert the title; add tests for experimental present, experimental absent, and combined deprecated+experimental (asserting callout ordering and that both precede the description).
- **`README.md`** — document the experimental callout.

## Testing

`deno test tests/` — 78 passed, 0 failed (75 baseline + 3 new). Built test-first: confirmed the new/changed tests fail against the unmodified renderer, then pass after the change.